### PR TITLE
Rebrand the module from thycotic to delinea

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Delinea DevOps Secrets Vault SDK for Go
 
-![Tests](https://github.com/thycotic/dsv-sdk-go/workflows/Tests/badge.svg)
+![Tests](https://github.com/DelineaXPM/dsv-sdk-go/workflows/Tests/badge.svg)
 
 A Golang API and examples for [Delinea](https://delinea.com/)
 [DevOps Secrets Vault](https://delinea.com/products/devops-secrets-management-vault).

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/thycotic/dsv-sdk-go
+module github.com/DelineaXPM/dsv-sdk-go
 
 go 1.13

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/thycotic/dsv-sdk-go/vault"
+	"github.com/DelineaXPM/dsv-sdk-go/vault"
 )
 
 func main() {


### PR DESCRIPTION
- Renamed the module to delinea
- Updated the readme badges to reflect the new GitHub location