### PR TITLE
Append v2 to module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/DelineaXPM/dsv-sdk-go
+module github.com/DelineaXPM/dsv-sdk-go/v2
 
 go 1.13

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/DelineaXPM/dsv-sdk-go/vault"
+	"github.com/DelineaXPM/dsv-sdk-go/v2/vault"
 )
 
 func main() {


### PR DESCRIPTION
Appending v2 to the module path so that the release can be properly tagged as 2.0.0.