### PR TITLE
feat: implement CreateSecret and DeleteSecret operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ _artifacts
 **/*/bin
 mage_output_file.go
 dist/
+/test_config.json

--- a/README.md
+++ b/README.md
@@ -53,14 +53,8 @@ Create `test_config.json`:
 const roleName = "test-role"
 ```
 
-`vault/secret_test.go` declares:
-
-```golang
-const secretName = "/test/secret"
-```
-
-The tests assume that `roleName` can exists and has privilege to create, read,
-and delete a client, and read `secretName`.
+The tests assume that `roleName` exists and has privilege to create, read,
+and delete a client, as well as create, read and delete secrets with a `test:` path prefix.
 
 ## Use
 

--- a/vault/secret.go
+++ b/vault/secret.go
@@ -22,7 +22,8 @@ type Secret struct {
 	secretResource
 }
 
-// Secret gets the secret at path from the DSV of the given tenant
+// Secret gets the secret at path from the DSV of the given tenant.
+// See https://dsv.secretsvaultcloud.com/api#operation/getSecret.
 func (v Vault) Secret(path string) (*Secret, error) {
 	data, err := v.accessResource(http.MethodGet, secretsResource, path, nil)
 	if err != nil {
@@ -32,6 +33,36 @@ func (v Vault) Secret(path string) (*Secret, error) {
 	secret := &Secret{}
 	if err := json.Unmarshal(data, secret); err != nil {
 		log.Printf("[DEBUG] error parsing response from /%s/%s: %q", secretsResource, path, data)
+		return nil, err
+	}
+	return secret, nil
+}
+
+// DeleteSecret deletes the secret at path from the DSV of the given tenant.
+// See https://dsv.secretsvaultcloud.com/api#operation/deleteSecret.
+func (v Vault) DeleteSecret(path string) error {
+	_, err := v.accessResource(http.MethodDelete, secretsResource, path, nil)
+	return err
+}
+
+// SecretRequest represents the request body of the CreateSecret operation.
+type SecretRequest struct {
+	Attributes map[string]interface{}
+	Data       map[string]interface{}
+	Description string
+}
+
+// CreateSecret creates the secret at path in the DSV of the given tenant.
+// See https://dsv.secretsvaultcloud.com/api#operation/createSecret.
+func (v Vault) CreateSecret(path string, req SecretRequest) (*Secret, error) {
+	d, err := v.accessResource(http.MethodPost, secretsResource, path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	secret := &Secret{}
+	if err := json.Unmarshal(d, secret); err != nil {
+		log.Printf("[DEBUG] error parsing response from /%s/%s: %q", secretsResource, path, d)
 		return nil, err
 	}
 	return secret, nil

--- a/vault/secret.go
+++ b/vault/secret.go
@@ -45,16 +45,16 @@ func (v Vault) DeleteSecret(path string) error {
 	return err
 }
 
-// SecretRequest represents the request body of the CreateSecret operation.
-type SecretRequest struct {
-	Attributes map[string]interface{}
-	Data       map[string]interface{}
-	Description string
+// SecretCreateRequest represents the request body of the CreateSecret operation.
+type SecretCreateRequest struct {
+	Attributes  map[string]interface{} `json:"attributes"`
+	Data        map[string]interface{} `json:"data"`
+	Description string                 `json:"description"`
 }
 
 // CreateSecret creates the secret at path in the DSV of the given tenant.
 // See https://dsv.secretsvaultcloud.com/api#operation/createSecret.
-func (v Vault) CreateSecret(path string, req SecretRequest) (*Secret, error) {
+func (v Vault) CreateSecret(path string, req SecretCreateRequest) (*Secret, error) {
 	d, err := v.accessResource(http.MethodPost, secretsResource, path, req)
 	if err != nil {
 		return nil, err

--- a/vault/secret.go
+++ b/vault/secret.go
@@ -54,7 +54,7 @@ type SecretCreateRequest struct {
 
 // CreateSecret creates the secret at path in the DSV of the given tenant.
 // See https://dsv.secretsvaultcloud.com/api#operation/createSecret.
-func (v Vault) CreateSecret(path string, req SecretCreateRequest) (*Secret, error) {
+func (v Vault) CreateSecret(path string, req *SecretCreateRequest) (*Secret, error) {
 	d, err := v.accessResource(http.MethodPost, secretsResource, path, req)
 	if err != nil {
 		return nil, err

--- a/vault/secret.go
+++ b/vault/secret.go
@@ -22,8 +22,9 @@ type Secret struct {
 	secretResource
 }
 
-// Secret gets the secret at path from the DSV of the given tenant.
-// See https://dsv.secretsvaultcloud.com/api#operation/getSecret.
+// Secret [gets the secret] at path from the DSV of the given tenant.
+//
+// [gets the secret]: https://dsv.secretsvaultcloud.com/api#operation/getSecret
 func (v Vault) Secret(path string) (*Secret, error) {
 	data, err := v.accessResource(http.MethodGet, secretsResource, path, nil)
 	if err != nil {
@@ -38,8 +39,9 @@ func (v Vault) Secret(path string) (*Secret, error) {
 	return secret, nil
 }
 
-// DeleteSecret deletes the secret at path from the DSV of the given tenant.
-// See https://dsv.secretsvaultcloud.com/api#operation/deleteSecret.
+// DeleteSecret [deletes the secret] at path from the DSV of the given tenant.
+//
+// [deletes the secret]: https://dsv.secretsvaultcloud.com/api#operation/deleteSecret
 func (v Vault) DeleteSecret(path string) error {
 	_, err := v.accessResource(http.MethodDelete, secretsResource, path, nil)
 	return err
@@ -52,8 +54,9 @@ type SecretCreateRequest struct {
 	Description string                 `json:"description"`
 }
 
-// CreateSecret creates the secret at path in the DSV of the given tenant.
-// See https://dsv.secretsvaultcloud.com/api#operation/createSecret.
+// CreateSecret [creates the secret] at path in the DSV of the given tenant.
+//
+// [creates the secret]: https://dsv.secretsvaultcloud.com/api#operation/createSecret
 func (v Vault) CreateSecret(path string, req *SecretCreateRequest) (*Secret, error) {
 	d, err := v.accessResource(http.MethodPost, secretsResource, path, req)
 	if err != nil {

--- a/vault/secret_test.go
+++ b/vault/secret_test.go
@@ -34,7 +34,7 @@ func TestSecret(t *testing.T) {
 func TestCreateSecret(t *testing.T) {
 	path := makeRandomSecretPath()
 	secret, err := dsv.CreateSecret(
-		path, SecretRequest{Data: map[string]interface{}{"foo": "bar"}},
+		path, SecretCreateRequest{Data: map[string]interface{}{"foo": "bar"}},
 	)
 
 	if err != nil {
@@ -63,7 +63,7 @@ func TestDeleteSecret(t *testing.T) {
 // as a cleanup function which should be deferred to remove the secret from the vault.
 func createSecret(t *testing.T, path string) (s *Secret, cleanup func()) {
 	t.Helper()
-	s, err := dsv.CreateSecret(path, SecretRequest{Data: map[string]interface{}{
+	s, err := dsv.CreateSecret(path, SecretCreateRequest{Data: map[string]interface{}{
 		"foo": "bar",
 	}})
 	if err != nil {

--- a/vault/secret_test.go
+++ b/vault/secret_test.go
@@ -18,3 +18,33 @@ func TestSecret(t *testing.T) {
 		t.Error("secret.Data is nil")
 	}
 }
+
+
+func TestCreateSecret(t *testing.T) {
+	secret, err := createSecret(secretName)
+
+	if err != nil {
+		t.Error("calling secrets.CreateSecret:", err)
+		return
+	}
+
+	if secret.Data == nil {
+		t.Error("secret.Data is nil")
+	}
+}
+
+func TestDeleteSecret(t *testing.T) {
+	createSecret("temporary")
+	err := dsv.DeleteSecret("temporary")
+
+	if err != nil {
+		t.Error("calling secrets.DeleteSecret:", err)
+		return
+	}
+}
+
+func createSecret(name string) (*Secret, error) {
+	return dsv.CreateSecret(name, SecretRequest{Data: map[string]interface{}{
+		"foo": "bar",
+	}})
+}

--- a/vault/secret_test.go
+++ b/vault/secret_test.go
@@ -2,15 +2,15 @@
 package vault
 
 import (
-	"testing"
 	"math/rand"
+	"testing"
 	"time"
 )
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyz"
 
 func init() {
-    rand.Seed(time.Now().UnixNano())
+	rand.Seed(time.Now().UnixNano())
 }
 
 func TestSecret(t *testing.T) {
@@ -29,7 +29,6 @@ func TestSecret(t *testing.T) {
 		t.Error("secret.Data is nil")
 	}
 }
-
 
 func TestCreateSecret(t *testing.T) {
 	path := makeRandomSecretPath()
@@ -84,8 +83,8 @@ func deleteSecret(t *testing.T, path string) {
 // makeRandomSecretPath creates a pseudo-random secret path.
 func makeRandomSecretPath() string {
 	b := make([]byte, 10)
-    for i := range b {
-        b[i] = letterBytes[rand.Intn(len(letterBytes))]
-    }
-	return "/test/"+string(b)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return "/test/" + string(b)
 }

--- a/vault/secret_test.go
+++ b/vault/secret_test.go
@@ -34,7 +34,7 @@ func TestSecret(t *testing.T) {
 func TestCreateSecret(t *testing.T) {
 	path := makeRandomSecretPath()
 	secret, err := dsv.CreateSecret(
-		path, SecretCreateRequest{Data: map[string]interface{}{"foo": "bar"}},
+		path, &SecretCreateRequest{Data: map[string]interface{}{"foo": "bar"}},
 	)
 
 	if err != nil {
@@ -63,7 +63,7 @@ func TestDeleteSecret(t *testing.T) {
 // as a cleanup function which should be deferred to remove the secret from the vault.
 func createSecret(t *testing.T, path string) (s *Secret, cleanup func()) {
 	t.Helper()
-	s, err := dsv.CreateSecret(path, SecretCreateRequest{Data: map[string]interface{}{
+	s, err := dsv.CreateSecret(path, &SecretCreateRequest{Data: map[string]interface{}{
 		"foo": "bar",
 	}})
 	if err != nil {

--- a/vault/secret_test.go
+++ b/vault/secret_test.go
@@ -1,16 +1,27 @@
 //go:build integration
 package vault
 
-import "testing"
+import (
+	"testing"
+	"math/rand"
+	"time"
+)
 
-const secretName = "/test/secret"
+const letterBytes = "abcdefghijklmnopqrstuvwxyz"
 
-// TestSecret tests Secret
+func init() {
+    rand.Seed(time.Now().UnixNano())
+}
+
 func TestSecret(t *testing.T) {
-	secret, err := dsv.Secret(secretName)
+	path := makeRandomSecretPath()
+	_, cleanup := createSecret(t, path)
+	defer cleanup()
+
+	secret, err := dsv.Secret(path)
 
 	if err != nil {
-		t.Error("calling secrets.Secret:", err)
+		t.Fatalf("Secret for path=%s: %s", path, err)
 		return
 	}
 
@@ -21,11 +32,16 @@ func TestSecret(t *testing.T) {
 
 
 func TestCreateSecret(t *testing.T) {
-	secret, err := createSecret(secretName)
+	path := makeRandomSecretPath()
+	secret, err := dsv.CreateSecret(
+		path, SecretRequest{Data: map[string]interface{}{"foo": "bar"}},
+	)
 
 	if err != nil {
-		t.Error("calling secrets.CreateSecret:", err)
+		t.Fatalf("CreateSecret for path=%s: %s", path, err)
 		return
+	} else {
+		defer func() { deleteSecret(t, path) }()
 	}
 
 	if secret.Data == nil {
@@ -34,17 +50,42 @@ func TestCreateSecret(t *testing.T) {
 }
 
 func TestDeleteSecret(t *testing.T) {
-	createSecret("temporary")
-	err := dsv.DeleteSecret("temporary")
+	path := makeRandomSecretPath()
+	_, _ = createSecret(t, path) // no cleanup required as test tries to delete anyway
 
+	err := dsv.DeleteSecret(path)
 	if err != nil {
-		t.Error("calling secrets.DeleteSecret:", err)
-		return
+		t.Errorf("DeleteSecret for path=%s: %s", path, err)
 	}
 }
 
-func createSecret(name string) (*Secret, error) {
-	return dsv.CreateSecret(name, SecretRequest{Data: map[string]interface{}{
+// createSecret creates a secret with given path and returns the created secret as well
+// as a cleanup function which should be deferred to remove the secret from the vault.
+func createSecret(t *testing.T, path string) (s *Secret, cleanup func()) {
+	t.Helper()
+	s, err := dsv.CreateSecret(path, SecretRequest{Data: map[string]interface{}{
 		"foo": "bar",
 	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanup = func() { deleteSecret(t, path) }
+	return
+}
+
+// deleteSecret deletes the secret given by path from the vault.
+func deleteSecret(t *testing.T, path string) {
+	t.Helper()
+	if err := dsv.DeleteSecret(path); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// makeRandomSecretPath creates a pseudo-random secret path.
+func makeRandomSecretPath() string {
+	b := make([]byte, 10)
+    for i := range b {
+        b[i] = letterBytes[rand.Intn(len(letterBytes))]
+    }
+	return "/test/"+string(b)
 }

--- a/vault/secret_test.go
+++ b/vault/secret_test.go
@@ -86,5 +86,5 @@ func makeRandomSecretPath() string {
 	for i := range b {
 		b[i] = letterBytes[rand.Intn(len(letterBytes))]
 	}
-	return "/test/" + string(b)
+	return "test:" + string(b)
 }


### PR DESCRIPTION
Closes #33.

I need this for the E2E tests of the External Secrets operator. My change is as minimal as possible, without touching e.g. `TestSecret`, though this may benefit from refactoring now that secrets can be created programmatically.